### PR TITLE
Add `prune-juice`, `hadolint`, and `packdeps` tools

### DIFF
--- a/.github/workflows/auto-update-dev-tools.yml
+++ b/.github/workflows/auto-update-dev-tools.yml
@@ -1,7 +1,8 @@
-# Uupdate the dockerfile with the latest versions of hlint and fourmolu
-# Creates a PR to update the dockerfile if new versions have been released
+# On a schedule, this workflow checks whether new tool versions have been
+# released. If so, this workflow runs `update-dev-tools.sh`, which updates the
+# tool versions in the Dockerfile. It then opens and auto-merges an update PR.
 name: dev-tools update
-on: 
+on:
   schedule:
     # run once, each monday+wednesday+friday, at 4AM PST (UTC-8:00)
     - cron: '0 12 * * 1,3,5'

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,20 +1,27 @@
-# Build the correct binaries
+# Build all tools except cabal-fmt and packdeps.
 FROM fossa/haskell-static-alpine:ghc-9.0.2 as builder-9.0
-LABEL org.opencontainers.image.source = "https://github.com/fossas/haskell-dev-tools"
-RUN cabal update && cabal install hlint-3.4.1 && cabal install fourmolu-0.7.0.1 
-# Replace symlinks with their actual files so we can slim down the image later
-RUN cp "$(readlink -f "$(which hlint)")" "$(readlink -f "$(which fourmolu)")" /root/.cabal/bin/
 
-# cabal-fmt doesn't build for ghc-9.0 yet, so we do a little sneaky.
-# The build from the previous GHC just works, so we use the old one.
-# hlint and fourmolu are very tightly coupled with GHC versions, but not cabal-fmt.
+RUN cabal update && \
+  cabal install --install-method=copy hlint-3.4.1 && \
+  cabal install --install-method=copy fourmolu-0.7.0.1 && \
+  cabal install --install-method=copy prune-juice-0.7 && \
+  cabal install --install-method=copy hadolint-2.11.0 && \
+  true
+
+# cabal-fmt and packdeps only build on GHC 8.10, but still work for projects
+# using GHC 9.
 FROM fossa/haskell-static-alpine:ghc-8.10.7 as builder-8.10
-RUN cabal update && cabal install cabal-fmt-0.1.5.1
-# Do the symlink-slim
-RUN cp "$(readlink -f "$(which cabal-fmt)")" /root/.cabal/bin/
 
-# Copy the binaries into a smaller image
+RUN cabal update && \
+  cabal install --install-method=copy cabal-fmt-0.1.5.1 && \
+  cabal install --install-method=copy packdeps-0.6.0.0 && \
+  true
+
+# Copy the built binaries into a smaller image.
 FROM fossa/haskell-static-alpine:ghc-9.0.2 as final
+
+LABEL org.opencontainers.image.source = "https://github.com/fossas/haskell-dev-tools"
+
 COPY --from=builder-9.0 /root/.cabal/bin/hlint /root/.cabal/bin/hlint
 COPY --from=builder-9.0 /root/.cabal/bin/fourmolu /root/.cabal/bin/fourmolu
 COPY --from=builder-8.10 /root/.cabal/bin/cabal-fmt /root/.cabal/bin/cabal-fmt

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -22,4 +22,7 @@ LABEL org.opencontainers.image.source = "https://github.com/fossas/haskell-dev-t
 
 COPY --from=builder-9.0 /root/.cabal/bin/hlint /root/.cabal/bin/hlint
 COPY --from=builder-9.0 /root/.cabal/bin/fourmolu /root/.cabal/bin/fourmolu
+COPY --from=builder-9.0 /root/.cabal/bin/prune-juice /root/.cabal/bin/prune-juice
+COPY --from=builder-9.0 /root/.cabal/bin/hadolint /root/.cabal/bin/hadolint
 COPY --from=builder-8.10 /root/.cabal/bin/cabal-fmt /root/.cabal/bin/cabal-fmt
+COPY --from=builder-8.10 /root/.cabal/bin/packdeps /root/.cabal/bin/packdeps

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,21 +1,19 @@
 # Build all tools except cabal-fmt and packdeps.
 FROM fossa/haskell-static-alpine:ghc-9.0.2 as builder-9.0
 
-RUN cabal update && \
-  cabal install --install-method=copy hlint-3.4.1 && \
-  cabal install --install-method=copy fourmolu-0.7.0.1 && \
-  cabal install --install-method=copy prune-juice-0.7 && \
-  cabal install --install-method=copy hadolint-2.11.0 && \
-  true
+RUN cabal update && cabal install --install-method=copy \
+  hlint-3.4.1 \
+  fourmolu-0.7.0.1 \
+  prune-juice-0.7 \
+  hadolint-2.11.0
 
 # cabal-fmt and packdeps only build on GHC 8.10, but still work for projects
 # using GHC 9.
 FROM fossa/haskell-static-alpine:ghc-8.10.7 as builder-8.10
 
-RUN cabal update && \
-  cabal install --install-method=copy cabal-fmt-0.1.5.1 && \
-  cabal install --install-method=copy packdeps-0.6.0.0 && \
-  true
+RUN cabal update && cabal install --install-method=copy \
+  cabal-fmt-0.1.5.1 \
+  packdeps-0.6.0.0
 
 # Copy the built binaries into a smaller image.
 FROM fossa/haskell-static-alpine:ghc-9.0.2 as final

--- a/src/update-dev-tools.sh
+++ b/src/update-dev-tools.sh
@@ -24,7 +24,7 @@ update_package () {
     _prefix="${temp_dir}/${package_name}"
     json_file="${_prefix}.json"
     version_file="${_prefix}.version"
-    
+
     get_versions "$package_name" "$json_file"
     extract_latest_version "$json_file" "$version_file"
 
@@ -53,6 +53,12 @@ execute () {
     update_package fourmolu "$_tempdir"
     log "Updating cabal-fmt"
     update_package cabal-fmt "$_tempdir"
+    log "Updating prune-juice"
+    update_package prune-juice "$_tempdir"
+    log "Updating packdeps"
+    update_package packdeps "$_tempdir"
+    log "Updating hadolint"
+    update_package hadolint "$_tempdir"
     # We don't care about the exit code, we just want the diff output
     log "Running diff to check for changes"
     diff "${dockerfile}.bak" "$dockerfile" || true


### PR DESCRIPTION
This PR adds:

- [prune-juice](https://hackage.haskell.org/package/prune-juice), which detects unused dependencies.
- [packdeps](https://hackage.haskell.org/package/packdeps), which detects outdated dependencies.
- [hadolint](https://hackage.haskell.org/package/hadolint), which is a Dockerfile linter.

I've built this image locally, and tested that the update script works locally.