### PR TITLE
Add code for including a rust toolchain and updating it.

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -19,7 +19,7 @@ RUN cabal update && cabal install --install-method=copy \
 FROM fossa/haskell-static-alpine:ghc-9.0.2 as final
 
 # Install rust toolchain
-RUN mkdir -p ~/.cargo/bin && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile=minimal -y --default-toolchain 1.63.0
+RUN /bin/ash -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | /bin/ash -s -- --profile=minimal -y --default-toolchain 1.63.0"
 ENV PATH="/root/.cargo/bin:$PATH"
 RUN rustup component add rustfmt && rustup component add clippy
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -18,6 +18,11 @@ RUN cabal update && cabal install --install-method=copy \
 # Copy the built binaries into a smaller image.
 FROM fossa/haskell-static-alpine:ghc-9.0.2 as final
 
+# Install rust toolchain
+RUN mkdir -p ~/.cargo/bin && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile=minimal -y --default-toolchain 1.63.0
+ENV PATH="/root/.cargo/bin:$PATH"
+RUN rustup component add rustfmt && rustup component add clippy
+
 LABEL org.opencontainers.image.source = "https://github.com/fossas/haskell-dev-tools"
 
 COPY --from=builder-9.0 /root/.cabal/bin/hlint /root/.cabal/bin/hlint

--- a/src/update-dev-tools.sh
+++ b/src/update-dev-tools.sh
@@ -69,7 +69,7 @@ execute () {
     log "Updating hadolint"
     update_package hadolint "$_tempdir"
     log "Updating rust"
-    update_rust $(get_latest_rust)
+    update_rust "$(get_latest_rust)"
     # We don't care about the exit code, we just want the diff output
     log "Running diff to check for changes"
     diff "${dockerfile}.bak" "$dockerfile" || true

--- a/src/update-dev-tools.sh
+++ b/src/update-dev-tools.sh
@@ -3,6 +3,15 @@
 # Don't source this file or this line won't work.
 dockerfile="$(dirname "$0")/Dockerfile"
 
+get_latest_rust () {
+    curl --silent https://raw.githubusercontent.com/rust-lang/rust/master/RELEASES.md | sed -nE 's/Version[[:space:]]+([0-9.]+).+/\1/p' | head -n 1
+}
+
+update_rust () {
+    # name=$1 version = $2
+    gsed --in-place -E "s/--default-toolchain [0-9.]+/--default-toolchain $1/" "$dockerfile"
+}
+
 get_versions () {
     # name=$1, json_file=$2
     curl --show-error --silent --location --header 'Accept: application/json' "https://hackage.haskell.org/package/${1}/preferred" > "$2"
@@ -59,6 +68,8 @@ execute () {
     update_package packdeps "$_tempdir"
     log "Updating hadolint"
     update_package hadolint "$_tempdir"
+    log "Updating rust"
+    update_rust $(get_latest_rust)
     # We don't care about the exit code, we just want the diff output
     log "Running diff to check for changes"
     diff "${dockerfile}.bak" "$dockerfile" || true

--- a/src/update-dev-tools.sh
+++ b/src/update-dev-tools.sh
@@ -9,7 +9,7 @@ get_latest_rust () {
 
 update_rust () {
     # name=$1 version = $2
-    gsed --in-place -E "s/--default-toolchain [0-9.]+/--default-toolchain $1/" "$dockerfile"
+    sed --in-place -E "s/--default-toolchain [0-9.]+/--default-toolchain $1/" "$dockerfile"
 }
 
 get_versions () {


### PR DESCRIPTION
When the `bdb` parser was added to fossa-cli, commands like `make check-ci` and `make fmt-ci` started to fail because `cargo` isn't available. This PR is an attempt to add them into this image. 

Some other alternatives:
1. We do something similar to this PR, but the rust version from a `rust-version` in fossa-cli's `Cargo.toml`. 
2. We edit the `check-ci` and `fmt-ci` targets to not check rust. It would be on developers to run those checks  manually when editing rust.

