### PR TITLE
Create an image based on ghc 9.4.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ repo is released warranty-free into the public domain, under
 
 The image is published as `ghcr.io/fossas/haskell-dev-tools:{version}`, where
 `version` is the GHC compiler version we target.
+See the [package page](https://ghcr.io/fossas/haskell-dev-tools) for more details.
 
 ## Updating the container
 
@@ -35,6 +36,11 @@ Once it's published, you can immediately use it in the CI at the
 fossas/fossa-cli repo.
 
 ## Changelog
+
+### GHC 9.4.8
+
+- GHC is now version 9.4.8
+- cabal-install is now version 3.10.2.0
 
 ### GHC 9.4.7
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -20,4 +20,4 @@ LABEL org.opencontainers.image.source = "https://github.com/fossas/haskell-dev-t
 COPY --from=builder-9.4 /root/.local/bin/hlint /root/.cabal/bin/hlint
 COPY --from=builder-9.4 /root/.local/bin/fourmolu /root/.cabal/bin/fourmolu
 COPY --from=builder-9.4 /root/.local/bin/cabal-fmt /root/.cabal/bin/cabal-fmt
-COPY --from=builder-9.0 /root/.cabal/bin/hadolint /root/.cabal/bin/hadolint
+COPY --from=builder-9.0 /root/.local/bin/hadolint /root/.local/bin/hadolint

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,11 +1,11 @@
 # Build all tools except hadolint.
-FROM fossa/haskell-static-alpine:ghc-9.4.7 as builder-9.4
+FROM fossa/haskell-static-alpine:ghc-9.4.8 as builder-9.4
 
 # By installing these separately, we prevent the dependecies of one package from conflicting with the others
 RUN cabal update && \
     cabal install --install-method=copy hlint-3.6.1 && \
-    cabal install --install-method=copy fourmolu-0.13.1.0 && \
-    cabal install --install-method=copy cabal-fmt-0.1.7
+    cabal install --install-method=copy fourmolu-0.14.1.0 && \
+    cabal install --install-method=copy cabal-fmt-0.1.9
 
 FROM fossa/haskell-static-alpine:ghc-9.0.2 as builder-9.0
 
@@ -13,7 +13,7 @@ RUN cabal update && \
     cabal install --install-method=copy hadolint-2.11.0
 
 # Copy the built binaries into a smaller image.
-FROM fossa/haskell-static-alpine:ghc-9.4.7 as final
+FROM fossa/haskell-static-alpine:ghc-9.4.8 as final
 
 LABEL org.opencontainers.image.source = "https://github.com/fossas/haskell-dev-tools"
 


### PR DESCRIPTION
It does what's on the tin. I've also upgraded fourmolu/cabal-fmt to the versions that the latest HLS (2.5.0.0) uses. 