### PR TITLE
Update to GHC 9.8.4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,10 +27,10 @@ jobs:
       uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v3
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-
@@ -38,7 +38,7 @@ jobs:
           ${{ runner.os }}-buildx-
 
     - name: Build and push image
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v6
       with:
         tags: 'ghcr.io/fossas/haskell-dev-tools:9.8.4'
         push: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,9 @@ jobs:
         username: fossabot
         password: ${{ github.token }}
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
 
@@ -37,11 +40,12 @@ jobs:
     - name: Build and push image
       uses: docker/build-push-action@v2
       with:
-        tags: 'ghcr.io/fossas/haskell-dev-tools:9.8.2'
+        tags: 'ghcr.io/fossas/haskell-dev-tools:9.8.4'
         push: true
         context: ./src
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new
+        platforms: linux/amd64,linux/arm64
 
     - # Temp fix
       # https://github.com/docker/build-push-action/issues/252

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    
+
     steps:
     - uses: actions/checkout@v2
 
@@ -36,12 +36,12 @@ jobs:
 
     - name: run shellcheck
       run: shellcheck **/*.*sh
-  
+
   docker-lint:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    
+
     steps:
     - uses: actions/checkout@v2
 
@@ -53,10 +53,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    
+
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
@@ -72,7 +75,7 @@ jobs:
     - name: Get git short hash
       id: shorthash
       run: |
-        echo "::set-output name=shorthash::$(git rev-parse --short HEAD)"    
+        echo "::set-output name=shorthash::$(git rev-parse --short HEAD)"
 
     - name: Build and push
       uses: docker/build-push-action@v2
@@ -82,6 +85,7 @@ jobs:
         tags: ${{ format('haskell-dev-tools-test:{0}', steps.shorthash.outputs.shorthash) }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new
+        platforms: linux/amd64,linux/arm64
 
     - # Temp fix
       # https://github.com/docker/build-push-action/issues/252

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -62,10 +62,10 @@ jobs:
       uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v3
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-
@@ -78,7 +78,7 @@ jobs:
         echo "::set-output name=shorthash::$(git rev-parse --short HEAD)"
 
     - name: Build and push
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v6
       with:
         context: ./src
         push: false

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ fossas/fossa-cli repo.
 
 ## Changelog
 
+### GHC 9.8.4
+
+- GHC is now version 9.8.4
+- cabal-install is now 3.12.1.0
+
 ### GHC 9.8.2
 
 - GHC is now version 9.8.2

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ fossas/fossa-cli repo.
 
 - GHC is now version 9.8.4
 - cabal-install is now 3.12.1.0
+- Multi-platform support: Build images for `linux/amd64` and `linux/arm64`
 
 ### GHC 9.8.2
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -4,7 +4,7 @@ FROM fossa/haskell-static-alpine:ghc-9.8.2 AS builder-9.8
 # By installing these separately, we prevent the dependecies of one package from conflicting with the others
 RUN cabal update && \
     cabal install --install-method=copy hlint-3.8 && \
-    cabal install --install-method=copy fourmolu-0.16.2.0 && \
+    cabal install --install-method=copy fourmolu-0.19.0.1 && \
     cabal install --install-method=copy cabal-fmt-0.1.12
 
 FROM fossa/haskell-static-alpine:ghc-9.0.2 AS builder-9.0

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,5 +1,4 @@
-# Build all tools except hadolint.
-FROM fossa/haskell-static-alpine:ghc-9.8.2 AS builder-9.8
+FROM fossa/haskell-static-alpine:ghc-9.8.4 AS builder-9.8
 
 # By installing these separately, we prevent the dependecies of one package from conflicting with the others
 RUN cabal update && \
@@ -7,17 +6,11 @@ RUN cabal update && \
     cabal install --install-method=copy fourmolu-0.19.0.1 && \
     cabal install --install-method=copy cabal-fmt-0.1.12
 
-FROM fossa/haskell-static-alpine:ghc-9.0.2 AS builder-9.0
-
-RUN cabal update && \
-    cabal install --install-method=copy hadolint-2.12.0
-
 # Copy the built binaries into a smaller image.
-FROM fossa/haskell-static-alpine:ghc-9.8.2 AS final
+FROM fossa/haskell-static-alpine:ghc-9.8.4 AS final
 
 LABEL org.opencontainers.image.source = "https://github.com/fossas/haskell-dev-tools"
 
 COPY --from=builder-9.8 /root/.local/bin/hlint /root/.cabal/bin/hlint
 COPY --from=builder-9.8 /root/.local/bin/fourmolu /root/.cabal/bin/fourmolu
 COPY --from=builder-9.8 /root/.local/bin/cabal-fmt /root/.cabal/bin/cabal-fmt
-COPY --from=builder-9.0 /root/.local/bin/hadolint /root/.local/bin/hadolint

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -2,7 +2,7 @@ FROM fossa/haskell-static-alpine:ghc-9.8.4 AS builder-9.8
 
 # By installing these separately, we prevent the dependecies of one package from conflicting with the others
 RUN cabal update && \
-    cabal install --install-method=copy hlint-3.8 && \
+    cabal install --install-method=copy hlint-3.10 && \
     cabal install --install-method=copy fourmolu-0.19.0.1 && \
     cabal install --install-method=copy cabal-fmt-0.1.12
 

--- a/src/update-dev-tools.sh
+++ b/src/update-dev-tools.sh
@@ -53,8 +53,6 @@ execute () {
     update_package fourmolu "$_tempdir"
     log "Updating cabal-fmt"
     update_package cabal-fmt "$_tempdir"
-    log "Updating hadolint"
-    update_package hadolint "$_tempdir"
     # We don't care about the exit code, we just want the diff output
     log "Running diff to check for changes"
     diff "${dockerfile}.bak" "$dockerfile" || true


### PR DESCRIPTION
- Update base image to GHC 9.8.4
- Add multi-platform build: `linux/amd64` and `linux/arm64`
- Remove `hadolint` from the image
- Update `fourmolu` to 0.19.0.1
- Update `hlint` to 3.10